### PR TITLE
Change password storage to YAML file using Viper

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,13 @@ Steps
   5. Open `entries/editor` to write your entry, save, then press enter on terminal.
       * This will delete the editor file and save it's encrypted contents into a timestamped entry file in `entries/`.
   6. To read your entries, type `r` instead of `w` after creating your first entry. 
+
+# Configuring the Password
+
+The password is now stored in a YAML file instead of `.internal/.passphrase`. To configure the password, create a `config.yaml` file in the project directory with the following content:
+
+```yaml
+password: "your_password_here"
+```
+
+Replace `"your_password_here"` with your actual password.

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,1 @@
+password: "your_password_here"

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
+	github.com/spf13/viper v1.10.1
 	golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2 // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b
 )


### PR DESCRIPTION
Update password storage to use YAML file with Viper

* Add `github.com/spf13/viper` dependency in `go.mod`.
* Import `viper` package in `pkg/journal/authentication/authenticate.go`.
* Replace reading password from `.internal/.passphrase` with reading from `config.yaml` using `viper`.
* Update `README.md` to reflect the new method of storing the password in a YAML file.
* Add `config.yaml` file to store the password.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jamesbury3/Journal-Go?shareId=f5f97d9a-b193-4ef0-94af-386e36f53d5f).